### PR TITLE
divide bmv properties

### DIFF
--- a/bmv/eth2/src/main/java/foundation/icon/btp/bmv/eth2/BMVProperties.java
+++ b/bmv/eth2/src/main/java/foundation/icon/btp/bmv/eth2/BMVProperties.java
@@ -31,8 +31,6 @@ public class BMVProperties {
 
     private byte[] srcNetworkID;
     private byte[] genesisValidatorsHash;
-    private byte[] currentSyncCommittee;
-    private byte[] nextSyncCommittee;
     private Address bmc;
     private byte[] ethBmc;
     private LightClientHeader finalizedHeader;
@@ -70,27 +68,6 @@ public class BMVProperties {
 
     void setBlockProofHeader(LightClientHeader header) {
         this.blockProofHeader = header;
-    }
-
-    byte[] getCurrentSyncCommittee() {
-        return currentSyncCommittee;
-    }
-
-    void setCurrentSyncCommittee(byte[] syncCommittee) {
-        this.currentSyncCommittee = syncCommittee;
-    }
-
-    public byte[] getNextSyncCommittee() {
-        return nextSyncCommittee;
-    }
-
-    public void setNextSyncCommittee(byte[] nextSyncCommittee) {
-        this.nextSyncCommittee = nextSyncCommittee;
-    }
-
-    public void setNextSyncCommittee(SyncCommittee nextSyncCommittee) {
-        byte[] value = nextSyncCommittee != null ? SyncCommittee.serialize(nextSyncCommittee) : null;
-        setNextSyncCommittee(value);
     }
 
     byte[] getGenesisValidatorsHash() {
@@ -136,8 +113,6 @@ public class BMVProperties {
         var object = new BMVProperties();
         object.setSrcNetworkID(r.readByteArray());
         object.setGenesisValidatorsHash(r.readByteArray());
-        object.setCurrentSyncCommittee(r.readByteArray());
-        object.setNextSyncCommittee(r.readNullable(byte[].class));
         object.setBmc(r.readAddress());
         object.setEthBmc(r.readByteArray());
         object.setFinalizedHeader(r.read(LightClientHeader.class));
@@ -149,11 +124,9 @@ public class BMVProperties {
     }
 
     public static void writeObject(ObjectWriter w, BMVProperties obj) {
-        w.beginList(10);
+        w.beginList(8);
         w.write(obj.srcNetworkID);
         w.write(obj.genesisValidatorsHash);
-        w.write(obj.currentSyncCommittee);
-        w.writeNullable(obj.nextSyncCommittee);
         w.write(obj.bmc);
         w.write(obj.ethBmc);
         w.write(obj.finalizedHeader);

--- a/bmv/eth2/src/main/java/foundation/icon/btp/bmv/eth2/BMVProperties.java
+++ b/bmv/eth2/src/main/java/foundation/icon/btp/bmv/eth2/BMVProperties.java
@@ -32,11 +32,6 @@ public class BMVProperties {
     private byte[] srcNetworkID;
     private byte[] genesisValidatorsHash;
     private Address bmc;
-    private byte[] ethBmc;
-    private LightClientHeader finalizedHeader;
-    private LightClientHeader blockProofHeader;
-    private BigInteger lastMsgSeq;
-    private BigInteger lastMsgSlot;
 
     public byte[] getSrcNetworkID() {
         return srcNetworkID;
@@ -54,52 +49,12 @@ public class BMVProperties {
         this.bmc = bmc;
     }
 
-    byte[] getEthBmc() {
-        return ethBmc;
-    }
-
-    void setEthBmc(byte[] ethBmc) {
-        this.ethBmc = ethBmc;
-    }
-
-    LightClientHeader getBlockProofHeader() {
-        return blockProofHeader;
-    }
-
-    void setBlockProofHeader(LightClientHeader header) {
-        this.blockProofHeader = header;
-    }
-
     byte[] getGenesisValidatorsHash() {
         return genesisValidatorsHash;
     }
 
     void setGenesisValidatorsHash(byte[] genesisValidatorsHash) {
         this.genesisValidatorsHash = genesisValidatorsHash;
-    }
-
-    LightClientHeader getFinalizedHeader() {
-        return finalizedHeader;
-    }
-
-    void setFinalizedHeader(LightClientHeader finalizedHeader) {
-        this.finalizedHeader = finalizedHeader;
-    }
-
-    public BigInteger getLastMsgSlot() {
-        return lastMsgSlot;
-    }
-
-    public void setLastMsgSlot(BigInteger lastMsgSlot) {
-        this.lastMsgSlot = lastMsgSlot;
-    }
-
-    public BigInteger getLastMsgSeq() {
-        return lastMsgSeq;
-    }
-
-    public void setLastMsgSeq(BigInteger lastMsgSeq) {
-        this.lastMsgSeq = lastMsgSeq;
     }
 
     public String getNetwork() {
@@ -114,25 +69,15 @@ public class BMVProperties {
         object.setSrcNetworkID(r.readByteArray());
         object.setGenesisValidatorsHash(r.readByteArray());
         object.setBmc(r.readAddress());
-        object.setEthBmc(r.readByteArray());
-        object.setFinalizedHeader(r.read(LightClientHeader.class));
-        object.setBlockProofHeader(r.readNullable(LightClientHeader.class));
-        object.setLastMsgSlot(r.readBigInteger());
-        object.setLastMsgSeq(r.readBigInteger());
         r.end();
         return object;
     }
 
     public static void writeObject(ObjectWriter w, BMVProperties obj) {
-        w.beginList(8);
+        w.beginList(3);
         w.write(obj.srcNetworkID);
         w.write(obj.genesisValidatorsHash);
         w.write(obj.bmc);
-        w.write(obj.ethBmc);
-        w.write(obj.finalizedHeader);
-        w.writeNullable(obj.blockProofHeader);
-        w.write(obj.lastMsgSlot);
-        w.write(obj.lastMsgSeq);
         w.end();
     }
 }

--- a/bmv/eth2/src/main/java/foundation/icon/btp/bmv/eth2/MessageProofProperties.java
+++ b/bmv/eth2/src/main/java/foundation/icon/btp/bmv/eth2/MessageProofProperties.java
@@ -1,0 +1,59 @@
+package foundation.icon.btp.bmv.eth2;
+
+import score.ObjectReader;
+import score.ObjectWriter;
+
+import java.math.BigInteger;
+
+public class MessageProofProperties {
+    private byte[] ethBmc;
+    private BigInteger lastMsgSeq;
+    private BigInteger lastMsgSlot;
+    public static final MessageProofProperties DEFAULT;
+
+    static {
+        DEFAULT = new MessageProofProperties();
+    }
+
+    public byte[] getEthBmc() {
+        return ethBmc;
+    }
+
+    public void setEthBmc(byte[] ethBmc) {
+        this.ethBmc = ethBmc;
+    }
+
+    public BigInteger getLastMsgSeq() {
+        return lastMsgSeq;
+    }
+
+    public void setLastMsgSeq(BigInteger lastMsgSeq) {
+        this.lastMsgSeq = lastMsgSeq;
+    }
+
+    public BigInteger getLastMsgSlot() {
+        return lastMsgSlot;
+    }
+
+    public void setLastMsgSlot(BigInteger lastMsgSlot) {
+        this.lastMsgSlot = lastMsgSlot;
+    }
+
+    public static MessageProofProperties readObject(ObjectReader r) {
+        r.beginList();
+        var object = new MessageProofProperties();
+        object.setEthBmc(r.readByteArray());
+        object.setLastMsgSeq(r.readBigInteger());
+        object.setLastMsgSlot(r.readBigInteger());
+        r.end();
+        return object;
+    }
+
+    public static void writeObject(ObjectWriter w, MessageProofProperties obj) {
+        w.beginList(3);
+        w.write(obj.ethBmc);
+        w.write(obj.lastMsgSeq);
+        w.write(obj.lastMsgSlot);
+        w.end();
+    }
+}


### PR DESCRIPTION
Optimize accesing DB
* Previously BMVProperties were too large.
* BMV sometimes accesses data that does not need to be accessed, so there is unnecessary overhead.