### PR TITLE
Optimize MessageProof decoding

### DIFF
--- a/bmv/btpblock/src/main/java/foundation/icon/btp/bmv/btpblock/BTPMessageVerifier.java
+++ b/bmv/btpblock/src/main/java/foundation/icon/btp/bmv/btpblock/BTPMessageVerifier.java
@@ -19,8 +19,6 @@ package foundation.icon.btp.bmv.btpblock;
 import foundation.icon.btp.lib.BMV;
 import foundation.icon.btp.lib.BMVStatus;
 import foundation.icon.btp.lib.BTPAddress;
-import foundation.icon.score.util.Logger;
-import foundation.icon.score.util.StringUtil;
 import score.Address;
 import score.Context;
 import score.VarDB;
@@ -33,7 +31,6 @@ import java.util.Arrays;
 import java.util.List;
 
 public class BTPMessageVerifier implements BMV {
-    private static final Logger logger = Logger.getLogger(BTPMessageVerifier.class);
     private static final String HASH = "keccak-256";
     private static final String SIGNATURE_ALG = "ecdsa-secp256k1";
     private final VarDB<BMVProperties> propertiesDB = Context.newVarDB("properties", BMVProperties.class);
@@ -242,11 +239,7 @@ public class BTPMessageVerifier implements BMV {
             }
         }
         if (expectedMessageCnt.intValue() != result.total) {
-            var rightProofNodes = messageProof.getRightProofNodes();
-            for (int i = 0; i < rightProofNodes.length; i++) {
-                logger.println("ProofInRight["+i+"] : " + "NumOfLeaf:"+rightProofNodes[i].getNumOfLeaf()
-                        + "value:" + StringUtil.bytesToHex(rightProofNodes[i].getValue()));
-            }
+            messageProof.printRightNodes();
             throw BMVException.unknown(
                     "mismatch MessageCount offset:" + result.offset +
                             ", expected:" + expectedMessageCnt +

--- a/bmv/btpblock/src/main/java/foundation/icon/btp/bmv/btpblock/MessageProof.java
+++ b/bmv/btpblock/src/main/java/foundation/icon/btp/bmv/btpblock/MessageProof.java
@@ -16,6 +16,7 @@
 
 package foundation.icon.btp.bmv.btpblock;
 
+import foundation.icon.score.util.StringUtil;
 import score.Context;
 import score.ObjectReader;
 import scorex.util.ArrayList;
@@ -23,11 +24,11 @@ import scorex.util.ArrayList;
 import java.util.List;
 
 public class MessageProof {
-    private final ProofNode[] leftProofNodes;
+    private final List<ProofNode> leftProofNodes;
     private final byte[][] messages;
-    private final ProofNode[] rightProofNodes;
+    private final List<ProofNode> rightProofNodes;
 
-    public MessageProof(ProofNode[] leftProofNodes, byte[][] messages, ProofNode[] rightProofNodes) {
+    public MessageProof(List<ProofNode> leftProofNodes, byte[][] messages, List<ProofNode> rightProofNodes) {
         this.leftProofNodes = leftProofNodes;
         this.messages = messages;
         this.rightProofNodes = rightProofNodes;
@@ -37,52 +38,32 @@ public class MessageProof {
         return messages;
     }
 
-    public ProofNode[] getLeftProofNodes() {
-        return leftProofNodes;
-    }
-
-    public ProofNode[] getRightProofNodes() {
-        return rightProofNodes;
-    }
-
     public static MessageProof readObject(ObjectReader r) {
         r.beginList();
         List<ProofNode> lNodes = new ArrayList<>();
         r.beginList();
-        while(r.hasNext()) {
+        while (r.hasNext()) {
             lNodes.add(r.read(ProofNode.class));
         }
         r.end();
-        var lSize = lNodes.size();
-        ProofNode[] leftProofNodes = new ProofNode[lSize];
-        for (int i = 0; i < lSize; i++){
-            leftProofNodes[i] = lNodes.get(i);
-        }
-        byte[][] messages;
         List<byte[]> messageList = new ArrayList<>();
         r.beginList();
-        while(r.hasNext()) {
+        while (r.hasNext()) {
             messageList.add(r.readByteArray());
         }
-        int messagesLength = messageList.size();
-        messages = new byte[messagesLength][];
-        for(int i = 0; i < messagesLength; i++) {
+        byte[][] messages = new byte[messageList.size()][];
+        for (int i = 0; i < messages.length; i++) {
             messages[i] = messageList.get(i);
         }
         r.end();
         List<ProofNode> rNodes = new ArrayList<>();
         r.beginList();
-        while(r.hasNext()) {
+        while (r.hasNext()) {
             rNodes.add(r.read(ProofNode.class));
         }
         r.end();
-        var rSize = rNodes.size();
-        ProofNode[] rightProofNodes = new ProofNode[rSize];
-        for (int i = 0; i < rSize; i++){
-            rightProofNodes[i] = rNodes.get(i);
-        }
         r.end();
-        return new MessageProof(leftProofNodes, messages, rightProofNodes);
+        return new MessageProof(lNodes, messages, rNodes);
     }
 
     public static MessageProof fromBytes(byte[] bytes) {
@@ -117,6 +98,16 @@ public class MessageProof {
             throw BMVException.unknown("total doesn't match total : " + total + ", node : " + rootNumOfLeaf);
         node.verify();
         return new ProveResult(node.getValue(), left, total);
+    }
+
+    public void printRightNodes() {
+        int i = 0;
+        for (ProofNode pn : rightProofNodes) {
+            Context.println("ProofInRight[" + i + "]"
+                    + ": numOfLeaf=" + pn.getNumOfLeaf()
+                    + ", value=" + StringUtil.bytesToHex(pn.getValue()));
+            i++;
+        }
     }
 
     public static class ProveResult {


### PR DESCRIPTION
- remove unnecessary List to Array conversion
- do not expose internal proof nodes